### PR TITLE
update npm module events behaviour

### DIFF
--- a/libs/Stream/SubscribeToStreamEvent.js
+++ b/libs/Stream/SubscribeToStreamEvent.js
@@ -10,6 +10,10 @@ function SubscribeToStreamEvent() {
 
     this.eventName = 'subscribe';
 
+}
+util.inherits(SubscribeToStreamEvent, StreamEvent);
+
+SubscribeToStreamEvent.prototype.emit = function(response) {
     var authProvider = this.getServer().getAuthProvider();
     var storageProvider = this.getServer().getStorageProvider();
 
@@ -17,12 +21,16 @@ function SubscribeToStreamEvent() {
     if (authProvider) {
         credentialsKey = authProvider.getCredentialsKey(this.getAuthCredentials());
     }
-
+    //save to DB then emit 'subscribe' event
+    var _self = this;
     storageProvider.storeUserSettingsAsync(this.getChannelLabel(), this.getUserSettings().toObject(), credentialsKey).then(function() {
-        // do nothing
+        var emitted = _self.getServer().emit(_self.getEventName(), _self, response);
+        if (!emitted) {
+            response.send();
+        }
     });
-}
-util.inherits(SubscribeToStreamEvent, StreamEvent);
+    return true;
+};
 
 /**
  * @inheritdoc

--- a/libs/VectorWatch.js
+++ b/libs/VectorWatch.js
@@ -45,7 +45,7 @@ function VectorWatch(options) {
 
     if (process.env.SCHEDULE_EXPRESSION) {
         _this.logger.info("Scheduler set to: " + process.env.SCHEDULE_EXPRESSION);
-        schedule.scheduleJob(process.env.SCHEDULE_EXPRESSION,  _this.executePushJob.bind(null,_this));
+        schedule.scheduleJob(process.env.SCHEDULE_EXPRESSION,  _this.executeScheduledJob.bind(null,_this));
     }
 
 }
@@ -56,7 +56,7 @@ util.inherits(VectorWatch, EventEmitter);
  * Receive this context and emit push events for all records from storage
  * @param context
  */
-VectorWatch.prototype.executePushJob = function(context) {
+VectorWatch.prototype.executeScheduledJob = function(context) {
     var _this = context;
     _this.getStorageProvider().getAllUserSettingsAsync().then(function (records) {
         if(records && records.length) {

--- a/libs/VectorWatch.js
+++ b/libs/VectorWatch.js
@@ -43,11 +43,9 @@ function VectorWatch(options) {
 
     this.logger = this._decideLogger(options);
 
-    if (process.env.SCHEDULER) {
-        //default once an hour
-        var scheduleRule = process.env.SCHEDULE_EXPRESSION ? process.env.SCHEDULE_EXPRESSION : "* */1 * * *";
+    if (process.env.SCHEDULE_EXPRESSION) {
         _this.logger.info("Scheduler set to: " + process.env.SCHEDULE_EXPRESSION);
-        schedule.scheduleJob(scheduleRule,  _this.executePushJob.bind(null,_this));
+        schedule.scheduleJob(process.env.SCHEDULE_EXPRESSION,  _this.executePushJob.bind(null,_this));
     }
 
 }
@@ -63,7 +61,7 @@ VectorWatch.prototype.executePushJob = function(context) {
     _this.getStorageProvider().getAllUserSettingsAsync().then(function (records) {
         if(records && records.length) {
             records.forEach(function (record) {
-                _this.emit("push", record);
+                _this.emit("schedule", record);
             });
         }
     });

--- a/libs/VectorWatch.js
+++ b/libs/VectorWatch.js
@@ -92,8 +92,8 @@ VectorWatch.prototype.setAuthProvider = function(authProvider) {
  */
 VectorWatch.prototype.getStorageProvider = function() {
     if (!this.storageProvider) {
-        var MemoryStorageProvider = require('vectorwatch-storageprovider-memory');
-        this.setStorageProvider(new MemoryStorageProvider());
+        var StorageProvider = require('vectorwatch-storageprovider');
+        this.setStorageProvider(new StorageProvider());
     }
 
     return this.storageProvider;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "body-parser": "^1.15.0",
     "request": "^2.69.0",
     "elasticsearch": "10.1.3",
-    "vectorwatch-storageprovider-memory": "~1.1.1",
+    "vectorwatch-storageprovider": "~1.0.0",
     "winston": "^2.2.0",
     "winston-elasticsearch": "^0.2.6",
     "graylog2": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vectorwatch-sdk",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "SDK for implementing VectorWatch streams and apps.",
   "main": "index.js",
   "scripts": {
@@ -16,7 +16,8 @@
     "vectorwatch-storageprovider-memory": "~1.1.1",
     "winston": "^2.2.0",
     "winston-elasticsearch": "^0.2.6",
-    "graylog2": "0.1.3"
+    "graylog2": "0.1.3",
+    "node-schedule": "^0.2.9"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
Added two new envVars: 
process.env.**SCHEDULER** - default scheduler should be used -> true/false
process.env.**SCHEDULE_EXPRESSION** - cron like expression, like specified at node-schedule github page (https://github.com/node-schedule/node-schedule). Default is once an hour (\* */1 \* \* *)

---

┬    ┬    ┬    ┬    ┬    ┬
│    │    │    │    │    |
│    │    │    │    │    └ day of week (0 - 7) (0 or 7 is Sun)
│    │    │    │    └───── month (1 - 12)
│    │    │    └────────── day of month (1 - 31)
│    │    └─────────────── hour (0 - 23)
│    └──────────────────── minute (0 - 59)
└───────────────────────── second (0 - 59, OPTIONAL)

Ex:

vectorWatch.on('push', function(record) {
    vectorWatch.logger.info(record);
})

Update 'subscribe' flow to save data to DB before emitting 'subscribe' event
