### PR TITLE
start server by default , add static logger to VectorWatch

### DIFF
--- a/libs/Stream/SubscribeToStreamResponse.js
+++ b/libs/Stream/SubscribeToStreamResponse.js
@@ -23,6 +23,25 @@ SubscribeToStreamResponse.prototype.setValue = function(value) {
     return this;
 };
 
+
+/**
+ * Sends back to the vector cloud a bad request error
+ * @param message {String}
+ */
+SubscribeToStreamResponse.prototype.sendInvalidDataError = function(message) {
+
+    var _channelLabel = this.event.getChannelLabel();
+    var _logger = this.server.logger;
+
+    this.getServer().getStorageProvider().removeUserSettingsAsync(_channelLabel).then(function() {
+        _logger.error("Delete from DB " + _channelLabel);
+    }).catch(function(err) {
+        _logger.error("Cannot delete from DB " + _channelLabel + " " + JSON.stringify(err));
+    });
+
+    SubscribeToStreamResponse.super_.prototype.sendBadRequestError.apply(this, message);
+};
+
 /**
  * @inheritdoc
  */

--- a/libs/VectorWatch.js
+++ b/libs/VectorWatch.js
@@ -15,6 +15,7 @@ var request = require('request');
 var url = require('url');
 var schedule = require('node-schedule');
 
+
 /**
  * @param [options] {Object}
  * @constructor
@@ -41,12 +42,17 @@ function VectorWatch(options) {
         _this.sendPushPackets(packets);
     });
 
-    this.logger = this._decideLogger(options);
+    VectorWatch.logger = this._decideLogger();
+    this.logger = VectorWatch.logger;
 
     if (process.env.SCHEDULE_EXPRESSION) {
         _this.logger.info("Scheduler set to: " + process.env.SCHEDULE_EXPRESSION);
         schedule.scheduleJob(process.env.SCHEDULE_EXPRESSION,  _this.executeScheduledJob.bind(null,_this));
     }
+
+    this.server = http.createServer(this.getMiddleware()).listen((process.env.PORT || 8080));
+    _this.logger.info("Server " + process.env.STREAM_UUID || process.env.APP_UUID + " started ");
+
 
 }
 
@@ -416,15 +422,15 @@ VectorWatch.prototype._decideLogger = function() {
 };
 
 /**
- * Creates an HTTP server to listen for VectorWatch events
- * @param port {Number}
- * @param cb {Function}
+ * @deprecated Creates an HTTP server to listen for VectorWatch events
+ * Server is now started by default. This method still can be used
+ * @param cb {Function} - execute cb after server is created
  */
 VectorWatch.prototype.createServer = function(cb) {
-    var server = http.createServer(this.getMiddleware());
-
-    server.listen((process.env.PORT || 8080), cb);
-    return server;
+    if (cb) {
+        cb();
+    }
+    return this.server;
 };
 
 VectorWatch.TTL = consts.TTL;

--- a/libs/VectorWatch.js
+++ b/libs/VectorWatch.js
@@ -185,13 +185,13 @@ VectorWatch.prototype.getMiddleware = function() {
                 response.setExpired(true);
             }, _this.getOption('eventMaxTimeout', 30000));
 
-            if (!event.emit(response)) {
-                response.send();
-            }
-
             response.on('send', function() {
                 clearTimeout(timeout);
             });
+
+            if (!event.emit(response)) {
+                response.send();
+            }
         });
     };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vectorwatch-sdk",
-  "version": "3.0.9",
+  "version": "4.0.0",
   "description": "SDK for implementing VectorWatch streams and apps.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vectorwatch-sdk",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "SDK for implementing VectorWatch streams and apps.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Addad static logger function.
 It is useful if we have multiple source code files and only one vectorWatch instance can be created (as the server is not started by default when you instantiate the object)

Usage: 
**V**ectorWatch.logger.info(....)
OR 
var **v**ectorWatch = new VectorWatch(); **v**ectorWatch.logger.info(....)
